### PR TITLE
Update VerificationBox.html

### DIFF
--- a/Resources/Private/Partials/ContentElements/VerificationBox.html
+++ b/Resources/Private/Partials/ContentElements/VerificationBox.html
@@ -18,7 +18,7 @@
                 </div>
             </f:if>
         </div>
-        <p class="sd-description">{description -> f:format.html()}</p>
+        <div class="sd-description">{description -> f:format.html()}</div>
         <div class="sd-buttons">
             <a href="{verificationUrl}" target="_blank" class="sd-button sd-learner">
                 <div class="sd-hint">


### PR DESCRIPTION
If the description is rendered with a paragraph, the content gets placed after the paragraph and the class assignment is lost. Using a DIV instead of a p for the description fixes this and displays the output correctly